### PR TITLE
Add missing DLL version and update to 1.1.1271.0.

### DIFF
--- a/code/res/assimp.rc
+++ b/code/res/assimp.rc
@@ -31,8 +31,8 @@ LANGUAGE LANG_GERMAN, SUBLANG_GERMAN
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,1,SVNRevision, 0
- PRODUCTVERSION 1,1,SVNRevision,0
+ FILEVERSION 1,1,1271, 0
+ PRODUCTVERSION 1,1,1271,0
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -50,12 +50,12 @@ BEGIN
             VALUE "Comments", "Licensed under a 3-clause BSD license"
             VALUE "CompanyName", "assimp team"
             VALUE "FileDescription", "Open Asset Import Library"
-            VALUE "FileVersion", 1,1,SVNRevision,0
+            VALUE "FileVersion", 1,1,1271,0
             VALUE "InternalName", "assimp "
-            VALUE "LegalCopyright", "Copyright (C) 2006-2010"
+            VALUE "LegalCopyright", "Copyright (C) 2006-2015"
             VALUE "OriginalFilename", "assimpNN.dll"
             VALUE "ProductName", "Open Asset Import Library"
-            VALUE "ProductVersion", 1,1,SVNRevision,0
+            VALUE "ProductVersion", 1,1,1271,0
 		,0
         END
     END

--- a/workspaces/vc114Assimp311/code/assimp.vcxproj
+++ b/workspaces/vc114Assimp311/code/assimp.vcxproj
@@ -806,6 +806,9 @@
       <Project>E9375290-F0B7-49E9-BE86-86B8C79B0E2C</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\..\code\res\assimp.rc" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/workspaces/vc114Assimp311/code/assimp.vcxproj.filters
+++ b/workspaces/vc114Assimp311/code/assimp.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="Windows-1252"?>
+<?xml version="1.0" encoding="Windows-1252"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\..\..\code\Assimp.cpp">
@@ -1187,9 +1187,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <CustomBuild Include="..\..\..\code\CMakeLists.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{E1E6EB57-EDA5-433B-81ED-AA5D9B6BA377}</UniqueIdentifier>
     </Filter>
@@ -1349,5 +1346,13 @@
     <Filter Include="unzip">
       <UniqueIdentifier>{A79ABAF7-3C15-444D-AC25-170136CD05AB}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{83fdb8f5-3fa5-4982-88e5-2e34f7edd367}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\..\code\res\assimp.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Please review this change. It fixes the issue that assimp.dll version information is missing.