### PR TITLE
Add debug information (.pdb) for release-noboost configuration

### DIFF
--- a/workspaces/vc14Assimp311/code/assimp.vcxproj
+++ b/workspaces/vc14Assimp311/code/assimp.vcxproj
@@ -284,9 +284,9 @@
       <AdditionalOptions> /machine:x64 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib;..\contrib\zlib\Release\zlibstatic.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImportLibrary>./../../../lib/$(ProjectName)_$(Configuration)_$(PlatformName)\$(ProjectName).lib</ImportLibrary>
-      <ProgramDataBaseFile>$(SolutionDir)/code/Release/assimp.pdb</ProgramDataBaseFile>
+      <ProgramDataBaseFile>$(OutDir)assimp.pdb</ProgramDataBaseFile>
       <SubSystem>Console</SubSystem>
       <Version>
       </Version>
@@ -813,3 +813,4 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+


### PR DESCRIPTION
Symbol files are important for further debugging or crash issue investigation, after discussion with @SebastianVoigt, we decide to adjust the build config to generate the pdb file for assimp