### PR TITLE
Prevent bad/failing stringstream to crash the export progress

### DIFF
--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -81,6 +81,10 @@ void ExportSceneCollada(const char* pFile, IOSystem* pIOSystem, const aiScene* p
 	// invoke the exporter 
 	ColladaExporter iDoTheExportThing( pScene, pIOSystem, path, file);
 
+	if (iDoTheExportThing.mOutput.fail() || iDoTheExportThing.mOutput.bad()) {
+		throw DeadlyExportError("could not export as the limit of the file size is reached.");
+	}
+
 	// we're still here - export successfully completed. Write result to the given IOSYstem
 	boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
 	if(outfile == NULL) {

--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -56,6 +56,13 @@ void ExportSceneObj(const char* pFile,IOSystem* pIOSystem, const aiScene* pScene
 	// invoke the exporter 
 	ObjExporter exporter(pFile, pScene);
 
+	if (exporter.mOutput.fail() ||
+		exporter.mOutput.bad() ||
+		exporter.mOutputMat.fail() ||
+		exporter.mOutputMat.bad()) {
+		throw DeadlyExportError("could not export as the limit of the file size is reached.");
+	}
+
 	// we're still here - export successfully completed. Write both the main OBJ file and the material script
 	{
 		boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));

--- a/code/PlyExporter.cpp
+++ b/code/PlyExporter.cpp
@@ -55,6 +55,10 @@ void ExportScenePly(const char* pFile,IOSystem* pIOSystem, const aiScene* pScene
 	// invoke the exporter 
 	PlyExporter exporter(pFile, pScene);
 
+	if (exporter.mOutput.fail() || exporter.mOutput.bad()) {
+		throw DeadlyExportError("could not export as the limit of the file size is reached.");
+	}
+
 	// we're still here - export successfully completed. Write the file.
 	boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
 	if(outfile == NULL) {

--- a/code/STLExporter.cpp
+++ b/code/STLExporter.cpp
@@ -55,6 +55,10 @@ void ExportSceneSTL(const char* pFile,IOSystem* pIOSystem, const aiScene* pScene
 	// invoke the exporter 
 	STLExporter exporter(pFile, pScene);
 
+	if (exporter.mOutput.fail() || exporter.mOutput.bad()) {
+		throw DeadlyExportError("could not export as the limit of the file size is reached.");
+	}
+
 	// we're still here - export successfully completed. Write the file.
 	boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
 	if(outfile == NULL) {
@@ -67,6 +71,10 @@ void ExportSceneSTLBinary(const char* pFile,IOSystem* pIOSystem, const aiScene* 
 {
 	// invoke the exporter 
 	STLExporter exporter(pFile, pScene, true);
+
+	if (exporter.mOutput.fail() || exporter.mOutput.bad()) {
+		throw DeadlyExportError("could not export as the limit of the file size is reached.");
+	}
 
 	// we're still here - export successfully completed. Write the file.
 	boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));

--- a/code/XFileExporter.cpp
+++ b/code/XFileExporter.cpp
@@ -81,6 +81,10 @@ void ExportSceneXFile(const char* pFile,IOSystem* pIOSystem, const aiScene* pSce
 	// invoke the exporter 
 	XFileExporter iDoTheExportThing( pScene, pIOSystem, path, file);
 
+	if (iDoTheExportThing.mOutput.fail() || iDoTheExportThing.mOutput.bad()) {
+		throw DeadlyExportError("could not export as the limit of the file size is reached.");
+	}
+
 	// we're still here - export successfully completed. Write result to the given IOSYstem
 	boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
 	if(outfile == NULL) {


### PR DESCRIPTION
assimp source is using Tabs and it's quite hard to type Tabs in a space-only VS.